### PR TITLE
Fix .gh-head-open accent colour in dark mode for mobile devices

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2286,7 +2286,7 @@ html.dark-mode .footer-cta-title {
 }
 
 @media (max-width: 767px) {
-    html.dark-mode .gh-head-open #gh-head .gh-head-actions {
+    html.dark-mode #gh-head .gh-head-actions {
         background-color: var(--color-darkmode);
     }
 }


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/84648368/230186919-80cd2bb4-bd4b-4184-8862-426061e6dda1.png)
### After
![image](https://user-images.githubusercontent.com/84648368/230187012-eba35229-c30c-481c-bb96-df85034f03bb.png)
